### PR TITLE
Update project name from eight-new to eight

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { VitePWA } from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? "/eight-new/" : "",
+  base: process.env.GITHUB_ACTIONS ? "/eight/" : "",
   plugins: [
     preact({
       prerender: {


### PR DESCRIPTION
Update Vite base path for GitHub Pages deployment to use /eight/ instead of /eight-new/. This ensures all assets (icons, sounds, etc.) load correctly when deployed.