### PR TITLE
Disable text selection and fix exercise layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -99,6 +99,13 @@ body {
   /* iOS momentum scrolling */
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+
+  /* Disable text selection for PWA experience */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none; /* Disable iOS callout menu */
 }
 
 /* ========================================
@@ -168,6 +175,11 @@ body {
   font-weight: 700;
   line-height: 1.2;
   padding: 0 var(--space-16);
+  /* Reserve space for two lines to prevent layout shift */
+  min-height: calc(var(--font-size-title1) * 1.2 * 2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ========================================
@@ -410,6 +422,8 @@ button:focus-visible {
 
   .exercise-name {
     font-size: var(--font-size-title2);
+    /* Update min-height for smaller font size */
+    min-height: calc(var(--font-size-title2) * 1.2 * 2);
   }
 }
 


### PR DESCRIPTION
- Disable text selection throughout app for better PWA experience
- Add user-select: none and touch-callout: none to body
- Reserve vertical space for two lines in exercise name to prevent layout shift
- Use min-height with flexbox centering for consistent spacing
- Update responsive breakpoint to maintain two-line space on small screens