### PR TITLE
Add pause feature to exercise screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ const App = () => {
       timeline,
       startedAt: Date.now(), // Update the start time for the new exercise
       secondsElapsedInSegment: 0,
+      isPaused: false,
     };
     speak(exercise.name);
     ensureTimer();
@@ -105,6 +106,11 @@ const App = () => {
     const timerId = window.setInterval(() => {
       setState((currentState) => {
         if (!currentState) return null;
+
+        // If paused, don't advance the timer
+        if (currentState.isPaused) {
+          return currentState;
+        }
 
         const { timeline, segmentIndex, index, startedAt } = currentState;
         const segment = timeline[segmentIndex];
@@ -178,6 +184,30 @@ const App = () => {
     }
   };
 
+  const handlePause = () => {
+    setState((currentState) => {
+      if (!currentState) return null;
+
+      if (currentState.isPaused) {
+        // Resuming: adjust startedAt to account for pause duration
+        const pauseDuration = Date.now() - (currentState.pausedAt || Date.now());
+        return {
+          ...currentState,
+          isPaused: false,
+          startedAt: currentState.startedAt + pauseDuration,
+          pausedAt: undefined,
+        };
+      } else {
+        // Pausing: record when we paused
+        return {
+          ...currentState,
+          isPaused: true,
+          pausedAt: Date.now(),
+        };
+      }
+    });
+  };
+
   const exercise = useMemo(() => {
     if (state == null) return null;
 
@@ -210,7 +240,9 @@ const App = () => {
       handleStop={handleStop}
       handleStart={handleStart}
       handleNext={handleNext}
+      handlePause={handlePause}
       progress={progress}
+      isPaused={state?.isPaused || false}
     />
   );
 };

--- a/src/components/AppView.tsx
+++ b/src/components/AppView.tsx
@@ -8,15 +8,17 @@ export interface AppViewProps {
   handleStop: () => void;
   handleStart: () => void;
   handleNext: () => void;
+  handlePause: () => void;
   progress: number;
+  isPaused: boolean;
 }
 
-const AppView = ({ exercise, handleStop, handleStart, handleNext, progress }: AppViewProps) => {
+const AppView = ({ exercise, handleStop, handleStart, handleNext, handlePause, progress, isPaused }: AppViewProps) => {
   return (
     <div className="app">
       {exercise ? (
         <>
-          <ExerciseView {...exercise} />
+          <ExerciseView {...exercise} onPause={handlePause} isPaused={isPaused} />
           <ControlButtons onStop={handleStop} onNext={handleNext} />
           <ProgressBar progress={progress} />
         </>

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -4,12 +4,22 @@ interface ControlButtonsProps {
 }
 
 export function ControlButtons({ onStop, onNext }: ControlButtonsProps) {
+  const handleStop = (e: MouseEvent) => {
+    e.stopPropagation();
+    onStop();
+  };
+
+  const handleNext = (e: MouseEvent) => {
+    e.stopPropagation();
+    onNext();
+  };
+
   return (
-    <div className="control-buttons">
-      <button className="stop-button" onClick={onStop}>
+    <div className="control-buttons" onClick={(e) => e.stopPropagation()}>
+      <button className="stop-button" onClick={handleStop}>
         Stop
       </button>
-      <button className="next-button" onClick={onNext}>
+      <button className="next-button" onClick={handleNext}>
         Next
       </button>
     </div>

--- a/src/components/ExerciseView.tsx
+++ b/src/components/ExerciseView.tsx
@@ -1,6 +1,7 @@
 import { Exercise, ExerciseSegment } from "../types";
 import { TimerCircle } from "./TimerCircle";
 import { SegmentIndicators } from "./SegmentIndicators";
+import { PauseOverlay } from "./PauseOverlay";
 
 export interface ExerciseViewProps {
   exercise: Exercise;
@@ -8,14 +9,31 @@ export interface ExerciseViewProps {
   currentSegmentIndex: number;
   elapsed: number;
   totalDuration: number;
+  onPause?: () => void;
+  isPaused?: boolean;
 }
 
-export function ExerciseView({ exercise, timeline, currentSegmentIndex, elapsed, totalDuration }: ExerciseViewProps) {
+export function ExerciseView({
+  exercise,
+  timeline,
+  currentSegmentIndex,
+  elapsed,
+  totalDuration,
+  onPause,
+  isPaused,
+}: ExerciseViewProps) {
+  const handleClick = () => {
+    if (onPause) {
+      onPause();
+    }
+  };
+
   return (
-    <div className="exercise-view">
+    <div className="exercise-view" onClick={handleClick}>
       <h2 className="exercise-name">{exercise.name}</h2>
       <TimerCircle elapsed={elapsed} totalDuration={totalDuration} />
       <SegmentIndicators segments={timeline} currentIndex={currentSegmentIndex} />
+      {isPaused && <PauseOverlay />}
     </div>
   );
 }

--- a/src/components/PauseOverlay.tsx
+++ b/src/components/PauseOverlay.tsx
@@ -1,0 +1,16 @@
+export function PauseOverlay() {
+  return (
+    <div className="pause-overlay">
+      <div className="pause-content">
+        <div className="pause-icon">
+          <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="18" y="16" width="8" height="32" rx="2" fill="currentColor" />
+            <rect x="38" y="16" width="8" height="32" rx="2" fill="currentColor" />
+          </svg>
+        </div>
+        <span className="pause-label">Paused</span>
+        <span className="pause-hint">Tap to resume</span>
+      </div>
+    </div>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -158,6 +158,7 @@ body {
    ======================================== */
 
 .exercise-view {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -165,6 +166,8 @@ body {
   align-items: center;
   gap: var(--space-32);
   padding: var(--space-20) 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .exercise-name {
@@ -376,6 +379,72 @@ button {
   background-color: var(--primary-color);
   transition: width 0.3s var(--ease-standard);
   border-radius: 2px;
+}
+
+/* ========================================
+   Pause Overlay
+   ======================================== */
+
+.pause-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  animation: fadeIn 0.2s var(--ease-out);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.pause-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-16);
+  animation: scaleIn 0.3s var(--ease-standard);
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.pause-icon {
+  color: rgba(255, 255, 255, 0.9);
+  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.3));
+}
+
+.pause-label {
+  font-size: var(--font-size-title1);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+  letter-spacing: -0.02em;
+}
+
+.pause-hint {
+  font-size: var(--font-size-body);
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 /* ========================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,6 @@ export interface AppState {
   timeline: ExerciseSegment[];
   startedAt: number; // Start time of the current exercise
   secondsElapsedInSegment: number; // Elapsed time since the start of the current segment
+  isPaused: boolean; // Whether the exercise is currently paused
+  pausedAt?: number; // Timestamp when the exercise was paused
 }


### PR DESCRIPTION
Implemented tap-to-pause feature that allows users to pause and resume exercises by tapping anywhere on the screen (excluding control buttons).

Key changes:
- Added isPaused and pausedAt fields to AppState
- Timer pauses when isPaused is true and adjusts startedAt on resume
- Created PauseOverlay component with Apple design (blur backdrop, pause icon, hints)
- ExerciseView handles tap events to toggle pause state
- Control buttons stop event propagation to prevent unwanted pause triggers
- Added smooth fade-in and scale-in animations for pause overlay
- Maintains wake lock during pause to keep screen active

The pause overlay features:
- Semi-transparent dark backdrop with blur effect
- Clear pause icon and "Paused" label
- "Tap to resume" hint text
- Smooth animations following Apple's design guidelines