### PR TITLE
Fix iOS announcement audio playback issue

### DIFF
--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -9,6 +9,30 @@ export type SoundHandle = {
   play: () => void;
 };
 
+// Shared AudioContext for all audio playback (critical for iOS)
+let sharedAudioContext: AudioContext | null = null;
+
+/**
+ * Get or create the shared AudioContext
+ * Must be called from a user interaction handler to work on iOS
+ */
+export function getAudioContext(): AudioContext {
+  if (!sharedAudioContext) {
+    sharedAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+    unlock(sharedAudioContext);
+  }
+  return sharedAudioContext;
+}
+
+/**
+ * Resume the AudioContext if it's suspended (iOS requirement)
+ */
+export async function ensureAudioContextResumed(): Promise<void> {
+  if (sharedAudioContext && sharedAudioContext.state === "suspended") {
+    await sharedAudioContext.resume();
+  }
+}
+
 function createSoundHandle(buffer: AudioBuffer, audioContext: AudioContext): SoundHandle {
   return {
     play: function () {
@@ -28,12 +52,30 @@ async function loadSound(url: string, audioContext: AudioContext): Promise<Sound
 }
 
 export async function load(fileUrls: string[]): Promise<SoundHandle[]> {
-  let audioContext = new (window.AudioContext || window.webkitAudioContext)();
-
-  unlock(audioContext);
-
+  const audioContext = getAudioContext();
   const soundHandles = await Promise.all(fileUrls.map((url) => loadSound(url, audioContext)));
   return soundHandles;
+}
+
+/**
+ * Load an audio file as an AudioBuffer (for use with AudioContext)
+ */
+export async function loadAudioBuffer(url: string): Promise<AudioBuffer> {
+  const audioContext = getAudioContext();
+  const response = await fetch(url);
+  const arrayBuffer = await response.arrayBuffer();
+  return audioContext.decodeAudioData(arrayBuffer);
+}
+
+/**
+ * Play an AudioBuffer through the shared AudioContext
+ */
+export function playAudioBuffer(buffer: AudioBuffer): void {
+  const audioContext = getAudioContext();
+  const source = audioContext.createBufferSource();
+  source.buffer = buffer;
+  source.connect(audioContext.destination);
+  source.start(0);
 }
 
 function unlock(context: AudioContext) {
@@ -46,12 +88,4 @@ function unlock(context: AudioContext) {
 
   // play the file. noteOn is the older version of start()
   source.start ? source.start(0) : (source as any).noteOn(0);
-
-  // by checking the play state after some time, we know if we're really unlocked
-  // setTimeout(function () {
-  //   if (source.playbackState === source.PLAYING_STATE || source.playbackState === source.FINISHED_STATE) {
-  //     // Hide the unmute button if the context is unlocked.
-  //     unmute.style.display = "none";
-  //   }
-  // }, 0);
 }


### PR DESCRIPTION
The issue was that MP3 announcements used HTMLAudioElement which requires user interaction for each play() call on iOS. When the timer auto-advanced to the next exercise, the play() happened inside setInterval - not from user interaction - so iOS blocked it.

Fixed by switching to Web Audio API (AudioContext/AudioBuffer) for MP3 playback, using the same shared AudioContext that's already unlocked on user interaction for rest/work sounds. Now all audio goes through the same unlocked context and plays reliably on iOS.